### PR TITLE
feat: Support Waline as comment

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ import { wrapCode } from './src/plugins/shiki-transformers.ts';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import vue from '@astrojs/vue';
 // import { transformerNotationDiff } from '@shikijs/transformers';
 // import { transformerNotationHighlight } from '@shikijs/transformers';
 import tailwindcss from '@tailwindcss/vite';
@@ -36,6 +37,7 @@ export default defineConfig({
     sitemap({ filter: (page) => !page.includes('/archives/') && !page.includes('/about/') }),
     pagefind(),
     mdx(),
+    vue(),
   ],
   markdown: {
     shikiConfig: {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@astrojs/mdx": "^4.1.0",
     "@astrojs/rss": "^4.0.11",
     "@astrojs/sitemap": "^3.2.1",
+    "@astrojs/vue": "^5.0.7",
     "@iconify-json/ic": "^1.2.2",
     "@iconify-json/material-symbols": "^1.2.14",
     "@iconify-json/mdi": "^1.2.3",
@@ -29,6 +30,7 @@
     "@swup/scripts-plugin": "^2.1.0",
     "@swup/scroll-plugin": "^3.3.2",
     "@tailwindcss/vite": "^4.0.9",
+    "@waline/client": "^3.5.5",
     "astro": "^5.4.1",
     "astro-compress": "2.3.5",
     "astro-icon": "^1.1.5",
@@ -56,7 +58,8 @@
     "swup": "^4.8.1",
     "tailwindcss": "^4.0.9",
     "typescript": "^5.7.3",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "vue": "^3.5.13"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/components/Comment.astro
+++ b/src/components/Comment.astro
@@ -2,6 +2,7 @@
 import { commentConfig } from '@/config';
 import Giscus from '@components/comment/Giscus.astro';
 import Twikoo from '@components/comment/Twikoo.astro';
+import Waline from '@components/comment/Waline.astro';
 ---
 
 <div id="page-comment">
@@ -12,6 +13,8 @@ import Twikoo from '@components/comment/Twikoo.astro';
           return <Twikoo />;
         case 'giscus':
           return <Giscus />;
+        case 'waline':
+          return <Waline />;
       }
     })()
   }

--- a/src/components/comment/Waline.astro
+++ b/src/components/comment/Waline.astro
@@ -3,6 +3,8 @@ import { commentConfig } from '@/config';
 import { Waline as WalineComponent } from '@waline/client/component';
 import '@waline/client/meta';
 import '@waline/client/style';
+// Need to be separated to avoid being sorted before `@waline/client/style` when formatting
+import '@/styles/waline.css';
 
 const walineConfig = commentConfig.waline!;
 ---

--- a/src/components/comment/Waline.astro
+++ b/src/components/comment/Waline.astro
@@ -8,6 +8,7 @@ const walineConfig = commentConfig.waline!;
 ---
 
 <WalineComponent
+  client:visible
   serverURL={walineConfig.serverURL}
   path="window.location.pathname"
   dark={false}

--- a/src/components/comment/Waline.astro
+++ b/src/components/comment/Waline.astro
@@ -1,0 +1,20 @@
+---
+import { commentConfig } from '@/config';
+import { Waline as WalineComponent } from '@waline/client/component';
+import '@waline/client/meta';
+import '@waline/client/style';
+
+const walineConfig = commentConfig.waline!;
+---
+
+<WalineComponent
+  serverURL={walineConfig.serverURL}
+  path="window.location.pathname"
+  dark={false}
+  meta={walineConfig.meta || ['nick', 'mail', 'link']}
+  requiredMeta={walineConfig.requiredMeta || []}
+  login={walineConfig.login || 'enable'}
+  wordLimit={walineConfig.wordLimit || 500}
+  pageSize={walineConfig.pageSize || 10}
+  reaction={walineConfig.reaction || false}
+/>

--- a/src/components/comment/Waline.astro
+++ b/src/components/comment/Waline.astro
@@ -7,12 +7,13 @@ import '@waline/client/style';
 import '@/styles/waline.css';
 
 const walineConfig = commentConfig.waline!;
+const pathName = walineConfig.path ? walineConfig.path(Astro.url.pathname) : Astro.url.pathname;
 ---
 
 <WalineComponent
   client:visible
   serverURL={walineConfig.serverURL}
-  path="window.location.pathname"
+  path={pathName}
   dark={false}
   meta={walineConfig.meta || ['nick', 'mail', 'link']}
   requiredMeta={walineConfig.requiredMeta || []}

--- a/src/config.ts
+++ b/src/config.ts
@@ -164,8 +164,8 @@ export const searchConfig: SearchConfig = {
 };
 
 export const commentConfig: CommentConfig = {
-  enable: false,
-  provider: 'twikoo',
+  enable: true,
+  provider: 'waline',
   twikoo: {
     envId: 'your-env-id',
   },
@@ -175,5 +175,11 @@ export const commentConfig: CommentConfig = {
     category: 'your-category',
     categoryId: 'your-category-id',
     mapping: 'og:title',
+  },
+  waline: {
+    serverURL: 'https://astral-halo-comment.netlify.app/.netlify/functions/comment',
+    wordLimit: 100, // Set a lower limit for demo site, to prevent abuse and save free database space cost.
+    pageSize: 10,
+    reaction: false,
   },
 };

--- a/src/styles/waline.css
+++ b/src/styles/waline.css
@@ -1,0 +1,44 @@
+:root {
+  /* 字体大小 */
+  --waline-font-size: 1rem;
+
+  /* 常规颜色 */
+  --waline-white: #fff;
+  --waline-light-grey: #999;
+  --waline-dark-grey: #666;
+
+  /* 主题色 */
+  --waline-theme-color: var(--color-primary);
+  --waline-active-color: var(--color-secondary);
+
+  /* 布局颜色 */
+  --waline-color: var(--color-base-content);
+  --waline-bg-color: var(--color-base-100);
+  --waline-bg-color-light: var(--color-base-200);
+  --waline-bg-color-hover: var(--color-base-200);
+  --waline-border-color: var(--color-base-200);
+  --waline-disable-bg-color: color-mix(in oklab, var(--color-base-200) 25%, transparent);
+  --waline-disable-color: color-mix(in oklab, var(--color-base-content) 75%, transparent);
+  --waline-code-bg-color: var(--color-base-100);
+
+  /* 特殊颜色 */
+  --waline-bq-color: #f0f0f0;
+
+  /* 头像 */
+  --waline-avatar-size: 3.25rem;
+  --waline-m-avatar-size: calc(var(--waline-avatar-size) * 9 / 13);
+
+  /* 徽章 */
+  --waline-badge-color: var(--color-accent);
+  --waline-badge-font-size: 0.775em;
+
+  /* 信息 */
+  --waline-info-bg-color: color-mix(in oklab, var(--color-base-content) 15%, transparent);
+  --waline-info-color: color-mix(in oklab, var(--color-base-content) 60%, transparent);
+  --waline-info-font-size: 0.625em;
+
+  /* 渲染选择 */
+  --waline-border: 1px solid var(--waline-border-color);
+  --waline-avatar-radius: 50%;
+  --waline-box-shadow: none;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -438,7 +438,7 @@ export type CommentConfig = {
    *
    * 评论的提供者。
    */
-  provider: 'twikoo' | 'giscus';
+  provider: 'twikoo' | 'giscus' | 'waline';
   /**
    * The configuration of Twikoo.
    *
@@ -565,5 +565,76 @@ export type CommentConfig = {
      * @default true
      */
     lazyLoad?: boolean;
+  };
+  /**
+   * The configuration of Waline.
+   *
+   * Waline 的配置。
+   *
+   * @see https://waline.js.org/
+   */
+  waline?: {
+    /**
+     * The server URL of Waline.
+     *
+     * Waline 的服务端地址。
+     *
+     * @see https://waline.js.org/reference/client/props.html#serverurl
+     */
+    serverURL: string;
+    /**
+     * Reviewer attributes of Waline.
+     *
+     * Waline 的评论者相关属性。
+     *
+     * @default ['nick', 'mail', 'link']
+     * @see https://waline.js.org/reference/client/props.html#meta
+     */
+    meta?: ('nick' | 'mail' | 'link')[];
+    /**
+     * Required reviewer attributes of Waline.
+     *
+     * Waline 的评论者必填属性。
+     *
+     * @default []
+     * @see https://waline.js.org/reference/client/props.html#requiredmeta
+     */
+    requiredMeta?: [] | ['nick'] | ['nick', 'mail'];
+    /**
+     * Whether to enable or force to login.
+     *
+     * 是否启用或强制登录。
+     *
+     * @default 'enable'
+     * @see https://waline.js.org/reference/client/props.html#login
+     */
+    login?: 'enable' | 'disable' | 'force';
+    /**
+     * The word limit of the comment.
+     *
+     * 评论的字数限制。
+     *
+     * @default 500
+     * @see https://waline.js.org/reference/client/props.html#wordlimit
+     */
+    wordLimit?: number;
+    /**
+     * The page size of the comments.
+     *
+     * 评论的分页大小。
+     *
+     * @default 10
+     * @see https://waline.js.org/reference/client/props.html#pagesize
+     */
+    pageSize?: number;
+    /**
+     * Whether to enable reactions.
+     *
+     * 是否启用表情。
+     *
+     * @default false
+     * @see https://waline.js.org/reference/client/props.html#reaction
+     */
+    reaction?: boolean | string[];
   };
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -583,6 +583,17 @@ export type CommentConfig = {
      */
     serverURL: string;
     /**
+     * The path processor of the page.
+     * The parameter is `Astro.url.pathname`, and the return value will be passed to Waline as `path`.
+     *
+     * 页面路径处理器。传入参数为 `Astro.url.pathname`，返回值将传入 Waline 作为 `path`。
+     *
+     * @default (path) => path
+     * @see https://docs.astro.build/reference/api-reference/#url
+     * @see https://waline.js.org/reference/client/props.html#path
+     */
+    path?: (path: string) => string;
+    /**
      * Reviewer attributes of Waline.
      *
      * Waline 的评论者相关属性。

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,16 +11,37 @@
       }
     ],
     "paths": {
-      "@assets/*": ["src/assets/*"],
-      "@components/*": ["src/components/*"],
-      "@constants/*": ["src/constants/*"],
-      "@i18n/*": ["src/i18n/*"],
-      "@layouts/*": ["src/layouts/*"],
-      "@scripts/*": ["src/scripts/*"],
-      "@utils/*": ["src/utils/*"],
-      "@/*": ["src/*"]
-    }
+      "@assets/*": [
+        "src/assets/*"
+      ],
+      "@components/*": [
+        "src/components/*"
+      ],
+      "@constants/*": [
+        "src/constants/*"
+      ],
+      "@i18n/*": [
+        "src/i18n/*"
+      ],
+      "@layouts/*": [
+        "src/layouts/*"
+      ],
+      "@scripts/*": [
+        "src/scripts/*"
+      ],
+      "@utils/*": [
+        "src/utils/*"
+      ],
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "jsx": "preserve"
   },
-  "include": ["src/**/*"],
-  "exclude": ["dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
This pull request includes the integration of [Vue](https://vuejs.org/) into the project, and supports to use [Waline](https://waline.js.org/en/) as comment.

This pull request also set the [Waline](https://waline.js.org/en/) as the comment for [living demo](https://astral-halo.netlify.app/).